### PR TITLE
Removing the rspec rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,4 @@
 require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
 
-desc 'Default: run specs.'
-task :default => :spec
-
-RSpec::Core::RakeTask.new(:spec)
+desc 'Default: build the gem.'
+task default: :build

--- a/sinatra-simple-navigation.gemspec
+++ b/sinatra-simple-navigation.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.rdoc_options     = ['--inline-source', '--charset=UTF-8']
 
   spec.add_runtime_dependency('simple-navigation', '>= 3.12.0')
+
+  spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
- Removing the rspec instructions from the Rakefile
- Adding rake as a development dependency
- Setting the default rake task to gem building
