### PR TITLE
Runtime dependency for minor version changes only

### DIFF
--- a/sinatra-simple-navigation.gemspec
+++ b/sinatra-simple-navigation.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.rdoc_options     = ['--inline-source', '--charset=UTF-8']
 
-  spec.add_runtime_dependency('simple-navigation', '>= 4.0.0')
+  spec.add_runtime_dependency('simple-navigation', '~> 4.0')
   spec.add_runtime_dependency('sinatra', '~> 1.0')
 
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Otherwise, changes in major versions like the ones we did to the `register` function in between `3.x` and `4.x` can break the Gem.

This actually happened for me when fixing `'sinatra-simple-navigation', '~> 3.7'` inside my Gemfile.
The old code loads `simple-navigation` v4 and breaks with
```ruby
simple-navigation-4.0.1/lib/simple_navigation/adapters/sinatra.rb:6:in `register':
wrong number of arguments (0 for 1)
```
__Implications__
This problem breaks the code for all users that rely on version `3.x`
Therefore you should probably release a new `3.x` patch version with `~> 3.0`, too! 