### PR TITLE
Version 5.0.0 - update sinatra dependency to work with 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-*5.0.0
+*4.1.0
 
 * update sinatra dependency to support 1.x through 2.x
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+*5.0.0
+
+* update sinatra dependency to support 1.x through 2.x
+
 *4.0.0
 
 * fix extension registration, depends on simple-navigation 4.0.0

--- a/lib/sinatra/simple_navigation/version.rb
+++ b/lib/sinatra/simple_navigation/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module SimpleNavigation
-    VERSION = '5.0.0'
+    VERSION = '4.1.0'
   end
 end

--- a/lib/sinatra/simple_navigation/version.rb
+++ b/lib/sinatra/simple_navigation/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module SimpleNavigation
-    VERSION = '4.0.0'
+    VERSION = '5.0.0'
   end
 end

--- a/sinatra-simple-navigation.gemspec
+++ b/sinatra-simple-navigation.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options     = ['--inline-source', '--charset=UTF-8']
 
   spec.add_runtime_dependency('simple-navigation', '~> 4.0')
-  spec.add_runtime_dependency('sinatra', '~> 1.0')
+  spec.add_runtime_dependency('sinatra', ['>= 1.0', '< 3.0'])
 
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
I tested against sinatra 2.0 and updated the gem dependency to allow use of sinatra version 1.x through 2.x. None of the API changes in sinatra 2.0 appear to affect simple navigation. Would greatly appreciated it if you could push an updated gem so we can upgrade projects that use this library.